### PR TITLE
Made statuses and labels optional

### DIFF
--- a/src/motion/models/__init__.py
+++ b/src/motion/models/__init__.py
@@ -25,15 +25,15 @@ class Project(BaseModel):
     name: str
     description: Optional[str] = None
     workspaceId: Optional[str] = None
-    status: Status
+    status: Optional[Status] = None
 
 
 class Workspace(BaseModel):
     id: str
     name: str
     teamId: Optional[str] = None
-    statuses: List[Status]
-    labels: List[Label]
+    statuses: Optional[List[Status]] = None
+    labels: Optional[List[Label]] = None
     type: str
 
 


### PR DESCRIPTION
Apparently API does not always return statuses or labels, had issues while retrieving tasks and projects from my Motion app:

`
tasks.0.project.status
  Field required [type=missing, input_value={'id': 'E9CgvG81ejdd6ZEpz...25-02-12T14:39:04.875Z'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
tasks.1.project.status
  Field required [type=missing, input_value={'id': 'E9CgvG81ejdd6ZEpz...25-02-12T14:39:04.875Z'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
tasks.2.project.status
  Field required [type=missing, input_value={'id': 'E9CgvG81ejdd6ZEpz...25-02-12T14:39:04.875Z'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
tasks.3.project.status
  Field required [type=missing, input_value={'id': 'E9CgvG81ejdd6ZEpz...25-02-12T14:39:04.875Z'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
tasks.4.project.status
  Field required [type=missing, input_value={'id': 'E9CgvG81ejdd6ZEpz...25-02-12T14:39:04.875Z'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
tasks.5.project.status
  Field required [type=missing, input_value={'id': 'E9CgvG81ejdd6ZEpz...25-02-12T14:39:04.875Z'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
tasks.6.project.status
  Field required [type=missing, input_value={'id': 'E9CgvG81ejdd6ZEpz...25-02-12T14:39:04.875Z'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
`